### PR TITLE
Use a base image instead of scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM alpine
 
 ADD ./out/funktion-linux-amd64 /bin/operator
 


### PR DESCRIPTION
This allows glog to work, since /tmp will be available. This also causes
env vars to be set, so $HOME is available for the config file lookup.

Fixes #31 

See https://github.com/coreos/flannel/issues/513 for more context.