### PR TITLE
Use oc instead of kubectl when talking to OpenShift

### DIFF
--- a/pkg/k8sutil/kubectl_helpers.go
+++ b/pkg/k8sutil/kubectl_helpers.go
@@ -50,8 +50,13 @@ func ResolveKubectlBinary(kubeclient *kubernetes.Clientset) (string, error) {
 }
 
 func isOpenShiftCluster(kubeclient *kubernetes.Clientset) bool {
-	// TODO
-	return false
+	// The presence of "/oapi" on the API server is our hacky way of
+	// determining if we're talking to OpenShift
+	err := kubeclient.Core().GetRESTClient().Get().AbsPath("/oapi").Do().Error()
+	if err != nil {
+		return false
+	}
+	return true
 }
 
 


### PR DESCRIPTION
Detect that we're talking to OpenShift by presence of the "/oapi" path
in the API server. There's probably a more canonical way to detect
OpenShift but this seems to work.

Fixes #34